### PR TITLE
US302498: IOS FAQ contents not loading - add  originWhitelist to WebView.

### DIFF
--- a/autoHeightWebView/index.ios.js
+++ b/autoHeightWebView/index.ios.js
@@ -154,6 +154,7 @@ export default class AutoHeightWebView extends PureComponent {
             }, style]}>
                 <WebView
                     {...this.props}
+                    originWhitelist={['*']}
                     onError={onError}
                     onLoad={onLoad}
                     onLoadStart={onLoadStart}


### PR DESCRIPTION
Issue: throwing 'possible unhandled promise rejection error unable to open url' when loading IOS web view.

Solution:
it seems that using source as {html: string} no longer works, without white-listing from RN v56 onwards.
Adding originWhitelist resolved this issue.  
https://github.com/react-native-community/react-native-webview/issues/26
https://facebook.github.io/react-native/docs/webview#source

Testing:
FAQ and giftCard features in IOS simulator