### PR TITLE
Fixed iOS app crash on web view link click

### DIFF
--- a/autoHeightWebView/index.ios.js
+++ b/autoHeightWebView/index.ios.js
@@ -118,7 +118,7 @@ export default class AutoHeightWebView extends PureComponent {
 
     onMessage(e) {
       if (this.props.onMessage) {
-        const messageObj = JSON.parse(e.nativeEvent.data);
+        const messageObj = JSON.parse(decodeURIComponent(decodeURIComponent(e.nativeEvent.data)));
         this.props.onMessage(messageObj);
       }
     }


### PR DESCRIPTION
**Description** : 
App getting crash for iOS on webview link click (phone , web url  etc).

**Details**:
Decoded message received from webview .

